### PR TITLE
Allow async-timeout 4.x too

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -19,7 +19,7 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 aiodns = {version = "*", optional = true, markers = "extra == \"speedups\""}
-async-timeout = ">=3.0,<4.0"
+async-timeout = ">=3.0.1,<5.0"
 attrs = ">=17.3.0"
 brotlipy = {version = "*", optional = true, markers = "extra == \"speedups\""}
 cchardet = {version = "*", optional = true, markers = "extra == \"speedups\""}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ version = "0.7.2"
 
 [tool.poetry.dependencies]
 aiohttp = {extras = ["speedups"], version = "^3.7.4"}
-async-timeout = "^3.0.1"
+async-timeout = ">=3.0.1,<5.0"
 click = ">=7.1.2,<9.0.0"
 python = "==3.*,>=3.8.0"
 requests = "^2.24.0"


### PR DESCRIPTION
There does not seem to be any need to restrict to the 3.x series;
doing so causes problems with projects that need a newer one for some
other purpose.

https://github.com/aio-libs/async-timeout/blob/f0a0914345b224448220aeb00d71e6a04a5d24bd/CHANGES.rst