### PR TITLE
Fixed issue with non-working unlock

### DIFF
--- a/surepy/surecli/__init__.py
+++ b/surepy/surecli/__init__.py
@@ -414,15 +414,14 @@ async def locking(ctx: click.Context, device_id: int, mode: str, token: str | No
         else:
             return
 
-        if lock_state:
-            console.print(f"setting {flap.name} to '{state}'...")
+        console.print(f"setting {flap.name} to '{state}'...")
 
-            if await sp.sac._set_lock_state(device_id=device_id, mode=lock_state) and (
-                device := await sp.get_device(device_id=device_id)
-            ):
-                console.print(f"✅ {device.name} set to '{state}' 🐾")
-            else:
-                console.print(f"❌ setting to '{state}' may have worked but something is fishy..!")
+        if await sp.sac._set_lock_state(device_id=device_id, mode=lock_state) and (
+            device := await sp.get_device(device_id=device_id)
+        ):
+            console.print(f"✅ {device.name} set to '{state}' 🐾")
+        else:
+            console.print(f"❌ setting to '{state}' may have worked but something is fishy..!")
 
         # await sp.sac.close_session()
 


### PR DESCRIPTION
Hi

The command `surepy locking -d <id> -m unlock` would not work (at least in my system). Because of the `if lock_state:` in the CLI locking command method which always resolves to false when 0 (and 0 is the enum value of unlock).

So the only change I suggest to fix this is to remove the `if lock_state:` condition completely - this condition is superfluous because the assignment block above makes sure that either lock_state has a reasonable value or returns otherwise. Another possibility would be to write `if lock_state in LockState:` which would make (doubly) sure that lock_state has a valid value.

Best regards, Chris
