### PR TITLE
Add the 'feederassign' command to add/remove pets from feeders

### DIFF
--- a/surepy/const.py
+++ b/surepy/const.py
@@ -18,6 +18,7 @@ DEVICE_RESOURCE: str = f"{BASE_RESOURCE}/device?with%5B%5D=children&with%5B%5D=t
 CONTROL_RESOURCE: str = "{BASE_RESOURCE}/device/{device_id}/control"
 POSITION_RESOURCE: str = "{BASE_RESOURCE}/pet/{pet_id}/position"
 ATTRIBUTES_RESOURCE: str = f"{BASE_RESOURCE}/start"
+DEVICE_TAG_RESOURCE: str = "{BASE_RESOURCE}/device/{device_id}/tag/{tag_id}"
 
 
 API_TIMEOUT = 45

--- a/surepy/entities/devices.py
+++ b/surepy/entities/devices.py
@@ -128,6 +128,35 @@ class FeederBowl:
     def raw_data(self) -> dict[str, int | float | str]:
         return self._data
 
+class Tag:
+    """Tags assigned to a device."""
+
+    def __init__(self, data: dict[str, int | float | str], feeder: Feeder):
+        """Initialize a Sure Petcare sensor."""
+
+        self._data: dict[str, int | float | str] = data
+
+    @property
+    def id(self) -> int:
+        return int(self._data["id"])
+
+    def index(self) -> int:
+        return int(self._data["index"])
+
+    def profile(self) -> int:
+        return int(self._data["profile"])
+
+    def version(self) -> str:
+        return self._data["version"]
+
+    def created_at(self) -> str:
+        return str(self._data["created_at"])
+
+    def updated_at(self) -> str:
+        return self._data["updated_at"]
+
+    def raw_data(self) -> dict[str, int | float | str]:
+        return self._data
 
 class Feeder(SurepyDevice):
     """Sure Petcare Cat- or Pet-Flap."""
@@ -139,6 +168,10 @@ class Feeder(SurepyDevice):
         self.bowls: dict[int, FeederBowl] = {}
 
         self.add_bowls()
+
+        self.tags: dict[int, Tag] = {}
+
+        self.add_tags()
 
     @property
     def bowl_count(self) -> int:
@@ -158,6 +191,10 @@ class Feeder(SurepyDevice):
         """Icon of the Felaqua."""
         return urlparse("https://surehub.io/assets/images/feeder-left-menu.png").geturl()
 
+    def add_tags(self) -> None:
+        if tags := self._data.get("tags"):
+            for tag in tags:
+                self.tags[tag["index"]] = Tag(data=tag, feeder=self)
 
 class Felaqua(SurepyDevice):
     """Sure Petcare Cat- or Pet-Flap."""


### PR DESCRIPTION
I was looking to figure out a way to automate adding/removing a pet from a feeder, when I stumbled upon this project. I realized this feature didn't exist, so I took some time to write it.

Example usage:
```
surepy feederassign -d 123456 -m list
surepy feederassign -d 123456 -m add -p 654321
surepy feederassign -d 123456 -m remove -p 654321
```

There are a few caveats though:
- This has not been thoroughly tested to account for all possible errors.
- I made various assumptions about coding and output style based on reading other pieces of the code.
- The HTTP DELETE operation does not return data, so I had to add a weird fake return to the "call" function. I'm sure this can be improved.

I hope you find this useful.

Please, let me know what improvements you would like to see before merging.

Thank you.