### PR TITLE
added http delete method used to remove pet from feeder

### DIFF
--- a/surepy/client.py
+++ b/surepy/client.py
@@ -217,7 +217,7 @@ class SureAPIClient:
         if not self._auth_token:
             self._auth_token = await self.get_token()
 
-        if method not in ["GET", "PUT", "POST"]:
+        if method not in ["GET", "PUT", "POST", "DELETE"]:
             raise HTTPException(f"unknown http method: {method}")
 
         response_data = None


### PR DESCRIPTION
Sure pet api utilizes DELETE for http methods when registering a tag with a feeder. Adding this will allow development to register a pet to a feeder, or other devices, as well as remove them from such devices. My primary use for this is to allow for a time based automation of when the feeder allows a certain cat to use it.
![image](https://user-images.githubusercontent.com/578100/217859376-79638663-ca3a-4252-906d-362e92db87a0.png)
