### PR TITLE
Add getters for aggregate report and dry food consumption

### DIFF
--- a/surepy/__init__.py
+++ b/surepy/__init__.py
@@ -297,7 +297,7 @@ class Surepy:
         """
         Retrieve the pet aggregate report.
         from_date and to_date should be in format: YYYY-MM-DD
-        CAUTION: not supplying a from_date and to_date could result in responses that are 1 MB or more with 500+ datapoints
+        CAUTION: not supplying a from_date and to_date could result in responses that are 1 MB or more with 500+ datapoints.
         """
         return (
             await self.sac.call(
@@ -311,23 +311,25 @@ class Surepy:
             )
         ) or {}
 
-    async def get_pet_dry_food_consumption_report(self, household_id: int, pet_id: int, from_date: str, to_date: str, app_mode: bool = True) -> int | float:
+    async def get_pet_food_consumption_report(self, household_id: int, pet_id: int, from_date: str, to_date: str, bowl_index: int = 0, app_mode: bool = True) -> int | float:
         """
         Retrieve the dry food consumed in grams per pet in given time range.
         from_date and to_date should be in format: YYYY-MM-DD
+            If you only want food consumption per day just pass in the same day twice (e.g. "2024-01-01" and "2024-01-01")
         app_mode will add up food consumption how the app does it.
-           Turning app_mode off may give more accurate results, but the results  won't match the app
+           Turning app_mode off may give more accurate results, but the results won't match the app.
+        bowl_index can be a 0 or a 1. If you only have one bowl the index is 0
         """
         report = await self.get_pet_aggregate_report(household_id, pet_id, from_date, to_date)
         datapoints = report.get('data').get('feeding').get('datapoints')
         total_food_change_in_grams = 0
         for datapoint in datapoints:
-            change = datapoint.get('weights')[0].get('change') # the first weight is always dry food. the second is wet food
+            change = datapoint.get('weights')[bowl_index].get('change')
             if app_mode and change <= -1:
-                # The app only counts food changes less than or equal to -1 and rounds to nearest integer
+                # The app only counts food changes less than or equal to -1 and rounds to nearest integer.
                 total_food_change_in_grams += round(abs(change))
             elif change < 0:
-                # Only counting changes that are negative as these represent feedings. Positive changes are presumed to be refills
+                # Only counting changes that are negative as these represent feedings. Positive changes are presumed to be refills.
                 total_food_change_in_grams += abs(change)
         return total_food_change_in_grams
 

--- a/surepy/__init__.py
+++ b/surepy/__init__.py
@@ -311,27 +311,36 @@ class Surepy:
             )
         ) or {}
 
-    async def get_pet_food_consumption_report(self, household_id: int, pet_id: int, from_date: str, to_date: str, bowl_index: int = 0, app_mode: bool = True) -> int | float:
+    async def get_pet_food_consumption_report(self, household_id: int, pet_id: int, from_date: str, to_date: str, bowl_index: int | None = 0, app_mode: bool = True) -> int | float | list[int]:
         """
         Retrieve the dry food consumed in grams per pet in given time range.
         from_date and to_date should be in format: YYYY-MM-DD
             If you only want food consumption per day just pass in the same day twice (e.g. "2024-01-01" and "2024-01-01")
         app_mode will add up food consumption how the app does it.
            Turning app_mode off may give more accurate results, but the results won't match the app.
-        bowl_index can be a 0 or a 1. If you only have one bowl the index is 0
+        bowl_index can be 0, 1 or None. If you only have one bowl the index is 0. Pass None to return a list with the consumption of each bowl.
         """
         report = await self.get_pet_aggregate_report(household_id, pet_id, from_date, to_date)
         datapoints = report.get('data').get('feeding').get('datapoints')
-        total_food_change_in_grams = 0
-        for datapoint in datapoints:
-            change = datapoint.get('weights')[bowl_index].get('change')
-            if app_mode and change <= -1:
-                # The app only counts food changes less than or equal to -1 and rounds to nearest integer.
-                total_food_change_in_grams += round(abs(change))
-            elif change < 0:
-                # Only counting changes that are negative as these represent feedings. Positive changes are presumed to be refills.
-                total_food_change_in_grams += abs(change)
-        return total_food_change_in_grams
+        total_food_change_in_grams = [0, 0]
+        if bowl_index is None:
+            bowl_index = [0, 1]
+        else:
+            bowl_index = [bowl_index]
+        for i in bowl_index:
+            for datapoint in datapoints:
+                if i < datapoint.get('bowl_count'):
+                    change = datapoint.get('weights')[i].get('change')
+                    if app_mode and change <= -1:
+                        # The app only counts food changes less than or equal to -1 and rounds to nearest integer.
+                        total_food_change_in_grams[i] += round(abs(change))
+                    elif change < 0:
+                        # Only counting changes that are negative as these represent feedings. Positive changes are presumed to be refills.
+                        total_food_change_in_grams[i] += abs(change)
+        if len(bowl_index) == 1:
+            return total_food_change_in_grams[bowl_index[0]]
+        else:
+            return total_food_change_in_grams
 
     async def get_pet(self, pet_id: int) -> Pet | None:
         if pet_id not in self.entities:


### PR DESCRIPTION
This PR adds two GETs:
* get_pet_aggregate_report
* get_pet_food_consumption_report

### Why this PR
I wanted to know how much food my pet was eating per day. With the above getters you can do the following to see how much food your pet ate on 2023-12-14. 
```python
consumed_food_grams = await surepy.get_pet_food_consumption_report(pet.household_id, pet.id, "2023-12-14", "2023-12-14")
```

### How it works
`get_pet_food_consumption_report` actually calls `get_pet_aggregate_report` to get the raw data. The sure petcare app gets these datapoints on the frontend/client and then calculates total food consumption on the clientside. The `get_pet_food_consumption_report` performs that calculation. 

One interesting oddity that took a while to figure out is how the client calculates total consumption. I've added an optional `app_mode` boolean parameter that lets you toggle between following the app's total consumption logic and raw summation. 

You can also pass in a `bowl_index` to specify which bowl you want to get pet food consumption from. If you only have one bowl the `bowl_index` is 0 and defaults to such. 