### PR TITLE
Added set_inside_pet method to allow this state to be configured

### DIFF
--- a/surepy/client.py
+++ b/surepy/client.py
@@ -450,3 +450,21 @@ class SureAPIClient:
 
         # return None
         raise SurePetcareError("ERROR SETTING INSIDE PET STATE - PLEASE CHECK IMMEDIATELY!")
+
+async def get_inside_pet(self, device_id: int, tag_id: int) -> dict[str, Any] | None:
+        """Set a pet as inside only or outside"""
+        resource = DEVICE_TAG_RESOURCE.format(
+            BASE_RESOURCE=BASE_RESOURCE, device_id=device_id, tag_id=tag_id
+        )
+    
+        if (
+            response := await self.call(
+                method="GET", resource=resource, device_id=device_id
+                )
+        ) and (response_data := response.get("data")):
+            id = response_data.get("profile")
+
+        return id
+        
+        # return None
+        raise SurePetcareError("ERROR GETTING INSIDE PET STATE - PLEASE CHECK IMMEDIATELY!")

--- a/surepy/client.py
+++ b/surepy/client.py
@@ -47,7 +47,7 @@ from .const import (
     SUREPY_USER_AGENT,
     USER_AGENT,
 )
-from .enums import Location, LockState
+from .enums import Location, LockState, InsidePet
 from .exceptions import SurePetcareAuthenticationError, SurePetcareConnectionError, SurePetcareError
 
 
@@ -429,12 +429,12 @@ class SureAPIClient:
         if response := await self.call(method="DELETE", resource=resource):
             return response
         
-    async def set_inside_pet(self, device_id: int, tag_id: int, profile_id: int) -> dict[str, Any] | None:
+    async def set_inside_pet(self, device_id: int, tag_id: int, profile_id: InsidePet) -> dict[str, Any] | None:
         """Set a pet as inside only or outside"""
         resource = DEVICE_TAG_RESOURCE.format(
             BASE_RESOURCE=BASE_RESOURCE, device_id=device_id, tag_id=tag_id
         )
-        data = {"profile": profile_id}
+        data = {"profile": int(profile_id.value)}
     
         if (
             response := await self.call(

--- a/surepy/client.py
+++ b/surepy/client.py
@@ -428,3 +428,25 @@ class SureAPIClient:
 
         if response := await self.call(method="DELETE", resource=resource):
             return response
+        
+    async def set_inside_pet(self, device_id: int, tag_id: int, profile_id: int) -> dict[str, Any] | None:
+        """Set a pet as inside only or outside"""
+        resource = DEVICE_TAG_RESOURCE.format(
+            BASE_RESOURCE=BASE_RESOURCE, device_id=device_id, tag_id=tag_id
+        )
+        data = {"profile": profile_id}
+    
+        if (
+            response := await self.call(
+                method="PUT", resource=resource, device_id=device_id, data=data
+                )
+        ) and (response_data := response.get("data")):
+            desired_state = data.get("profile")
+            state = response_data.get("profile")
+
+            # check if the state is correctly updated
+            if state == desired_state:
+                return response
+
+        # return None
+        raise SurePetcareError("ERROR SETTING INSIDE PET STATE - PLEASE CHECK IMMEDIATELY!")

--- a/surepy/client.py
+++ b/surepy/client.py
@@ -462,6 +462,6 @@ async def get_inside_pet(self, device_id: int, tag_id: int) -> int | None:
                 method="GET", resource=resource, device_id=device_id
                 )
         ) and (response_data := response.get("data")):
-            id = await response_data.get("profile")
+            id = response_data.get("profile")
 
         return id

--- a/surepy/client.py
+++ b/surepy/client.py
@@ -451,8 +451,8 @@ class SureAPIClient:
         # return None
         raise SurePetcareError("ERROR SETTING INSIDE PET STATE - PLEASE CHECK IMMEDIATELY!")
 
-async def get_inside_pet(self, device_id: int, tag_id: int) -> dict[str, Any] | None:
-        """Set a pet as inside only or outside"""
+async def get_inside_pet(self, device_id: int, tag_id: int) -> int | None:
+        """Get info on inside only or outside"""
         resource = DEVICE_TAG_RESOURCE.format(
             BASE_RESOURCE=BASE_RESOURCE, device_id=device_id, tag_id=tag_id
         )
@@ -465,6 +465,3 @@ async def get_inside_pet(self, device_id: int, tag_id: int) -> dict[str, Any] | 
             id = response_data.get("profile")
 
         return id
-        
-        # return None
-        raise SurePetcareError("ERROR GETTING INSIDE PET STATE - PLEASE CHECK IMMEDIATELY!")

--- a/surepy/client.py
+++ b/surepy/client.py
@@ -462,6 +462,6 @@ async def get_inside_pet(self, device_id: int, tag_id: int) -> int | None:
                 method="GET", resource=resource, device_id=device_id
                 )
         ) and (response_data := response.get("data")):
-            id = response_data.get("profile")
+            id = await response_data.get("profile")
 
         return id

--- a/surepy/entities/__init__.py
+++ b/surepy/entities/__init__.py
@@ -86,3 +86,17 @@ class PetActivity(PetLocationData):
 @dataclass
 class PetLocation(PetLocationData):
     pass
+
+
+@dataclass
+class PetInsideData:
+
+    profile: InsidePet
+
+    def __str__(self) -> str:
+        return self.where.name.title()
+
+
+@dataclass
+class StateInside(PetInsideData):
+    pass

--- a/surepy/entities/__init__.py
+++ b/surepy/entities/__init__.py
@@ -86,17 +86,3 @@ class PetActivity(PetLocationData):
 @dataclass
 class PetLocation(PetLocationData):
     pass
-
-
-@dataclass
-class PetInsideData:
-
-    profile: InsidePet
-
-    def __str__(self) -> str:
-        return self.where.name.title()
-
-
-@dataclass
-class StateInside(PetInsideData):
-    pass

--- a/surepy/entities/__init__.py
+++ b/surepy/entities/__init__.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pprint import pformat
 from typing import Any
 
-from surepy.enums import EntityType, Location
+from surepy.enums import EntityType, Location, InsidePet
 
 
 class SurepyEntity(ABC):
@@ -85,4 +85,18 @@ class PetActivity(PetLocationData):
 
 @dataclass
 class PetLocation(PetLocationData):
+    pass
+
+
+@dataclass
+class PetInsideData:
+
+    profile: InsidePet
+
+    def __str__(self) -> str:
+        return self.where.name.title()
+
+
+@dataclass
+class StateInside(PetInsideData):
     pass

--- a/surepy/entities/pet.py
+++ b/surepy/entities/pet.py
@@ -135,11 +135,6 @@ class Pet(SurepyEntity):
         return self.drinking.at if self.drinking else None
 
     @property
-    def inside_only(self) -> bool:
-        """State of inside only."""
-        return bool(self.profile_id.profile == InsidePet.INSIDE_ONLY)
-    
-    @property
     def profile_id(self) -> StateInside:
         """State of inside only."""
         profile = self._data.get("profile", {})

--- a/surepy/entities/pet.py
+++ b/surepy/entities/pet.py
@@ -138,6 +138,8 @@ class Pet(SurepyEntity):
     @property
     def profile_id(self) -> StateInside:
         """State of inside only."""
+        device_id = self._data.get("device_id", {}),
+        tag_id = self._data.get("tag_id", {}),
         # pylint: disable=no-member
         return StateInside(
             profile=InsidePet(get_inside_pet(tag_id := self._data.get("device_id",tag_id := self._data.get("tag_id"))))

--- a/surepy/entities/pet.py
+++ b/surepy/entities/pet.py
@@ -138,10 +138,10 @@ class Pet(SurepyEntity):
     @property
     def profile_id(self) -> StateInside:
         """State of inside only."""
-        device_id = self._data.get("device_id", {}),
-        tag_id = self._data.get("tag_id", {}),
+        device_id = int(self._data.get("device_id", {})),
+        tag_id = int(self._data.get("tag_id", {})),
         # pylint: disable=no-member
         return StateInside(
-            profile=InsidePet(get_inside_pet(device_id,tag_id))
+            profile=InsidePet(int(get_inside_pet(device_id, tag_id)))
         )
     

--- a/surepy/entities/pet.py
+++ b/surepy/entities/pet.py
@@ -142,6 +142,6 @@ class Pet(SurepyEntity):
         tag_id = self._data.get("tag_id", {}),
         # pylint: disable=no-member
         return StateInside(
-            profile=InsidePet(get_inside_pet(device_id, tag_id))
+            profile=InsidePet(get_inside_pet(self, device_id, tag_id))
         )
     

--- a/surepy/entities/pet.py
+++ b/surepy/entities/pet.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import Any
 from urllib.parse import urlparse
 
+from surepy.client import get_inside_pet
 from surepy.entities import PetActivity, PetLocation, StateDrinking, StateFeeding, SurepyEntity, StateInside
 from surepy.entities.states import PetState
 from surepy.enums import EntityType, FoodType, Location, InsidePet
@@ -139,6 +140,6 @@ class Pet(SurepyEntity):
         """State of inside only."""
         # pylint: disable=no-member
         return StateInside(
-            profile = self._data.get("profile", {})
+            profile=InsidePet(get_inside_pet(tag_id := self._data.get("device_id",tag_id := self._data.get("tag_id"))))
         )
     

--- a/surepy/entities/pet.py
+++ b/surepy/entities/pet.py
@@ -12,9 +12,9 @@ from datetime import datetime
 from typing import Any
 from urllib.parse import urlparse
 
-from surepy.entities import PetActivity, PetLocation, StateDrinking, StateFeeding, SurepyEntity
+from surepy.entities import PetActivity, PetLocation, StateDrinking, StateFeeding, SurepyEntity, StateInside
 from surepy.entities.states import PetState
-from surepy.enums import EntityType, FoodType, Location
+from surepy.enums import EntityType, FoodType, Location, InsidePet
 
 
 class Pet(SurepyEntity):
@@ -133,3 +133,18 @@ class Pet(SurepyEntity):
     @property
     def last_drink(self) -> datetime | None:
         return self.drinking.at if self.drinking else None
+
+    @property
+    def inside_only(self) -> bool:
+        """State of inside only."""
+        return bool(self.profile_id.profile == InsidePet.INSIDE_ONLY)
+    
+    @property
+    def profile_id(self) -> StateInside:
+        """State of inside only."""
+        profile = self._data.get("profile", {})
+        # pylint: disable=no-member
+        return StateInside(
+            profile=StateInside(profile.get("profile", InsidePet.INSIDE_ONLY.value)),
+        )
+    

--- a/surepy/entities/pet.py
+++ b/surepy/entities/pet.py
@@ -142,6 +142,6 @@ class Pet(SurepyEntity):
         tag_id = self._data.get("tag_id", {}),
         # pylint: disable=no-member
         return StateInside(
-            profile=InsidePet(get_inside_pet(self, device_id, tag_id))
+            profile=get_inside_pet(self, device_id, tag_id)
         )
     

--- a/surepy/entities/pet.py
+++ b/surepy/entities/pet.py
@@ -15,7 +15,7 @@ from urllib.parse import urlparse
 from surepy.client import get_inside_pet
 from surepy.entities import PetActivity, PetLocation, StateDrinking, StateFeeding, SurepyEntity, StateInside
 from surepy.entities.states import PetState
-from surepy.enums import EntityType, FoodType, Location, InsidePet
+from surepy.enums import EntityType, FoodType, Location
 
 
 class Pet(SurepyEntity):
@@ -136,12 +136,11 @@ class Pet(SurepyEntity):
         return self.drinking.at if self.drinking else None
     
     @property
-    def profile_id(self) -> StateInside:
+    def profile_id(self) -> int:
         """State of inside only."""
         device_id = self._data.get("device_id", {}),
         tag_id = self._data.get("tag_id", {}),
+        profile=get_inside_pet(self, device_id, tag_id),
         # pylint: disable=no-member
-        return StateInside(
-            profile=get_inside_pet(self, device_id, tag_id)
-        )
+        return profile
     

--- a/surepy/entities/pet.py
+++ b/surepy/entities/pet.py
@@ -137,7 +137,8 @@ class Pet(SurepyEntity):
     @property
     def profile_id(self) -> StateInside:
         """State of inside only."""
-        profile = self._data.get("profile", {})
         # pylint: disable=no-member
-        return profile
+        return StateInside(
+            profile = self._data.get("profile", {})
+        )
     

--- a/surepy/entities/pet.py
+++ b/surepy/entities/pet.py
@@ -136,12 +136,12 @@ class Pet(SurepyEntity):
         return self.drinking.at if self.drinking else None
     
     @property
-    def profile_id(self) -> StateInside:
+    async def profile_id(self) -> StateInside:
         """State of inside only."""
         device_id = self._data.get("device_id", {}),
         tag_id = self._data.get("tag_id", {}),
         # pylint: disable=no-member
         return StateInside(
-            profile=get_inside_pet(self, device_id, tag_id),
+            profile=await get_inside_pet(self, device_id, tag_id),
             )
     

--- a/surepy/entities/pet.py
+++ b/surepy/entities/pet.py
@@ -138,10 +138,10 @@ class Pet(SurepyEntity):
     @property
     def profile_id(self) -> StateInside:
         """State of inside only."""
-        device_id = int(self._data.get("device_id", {})),
-        tag_id = int(self._data.get("tag_id", {})),
+        device_id = self._data.get("device_id", {}),
+        tag_id = self._data.get("tag_id", {}),
         # pylint: disable=no-member
         return StateInside(
-            profile=InsidePet(int(get_inside_pet(device_id, tag_id)))
+            profile=InsidePet(get_inside_pet(device_id, tag_id))
         )
     

--- a/surepy/entities/pet.py
+++ b/surepy/entities/pet.py
@@ -133,13 +133,11 @@ class Pet(SurepyEntity):
     @property
     def last_drink(self) -> datetime | None:
         return self.drinking.at if self.drinking else None
-
+    
     @property
     def profile_id(self) -> StateInside:
         """State of inside only."""
         profile = self._data.get("profile", {})
         # pylint: disable=no-member
-        return StateInside(
-            profile=StateInside(profile.get("profile", InsidePet.INSIDE_ONLY.value)),
-        )
+        return profile
     

--- a/surepy/entities/pet.py
+++ b/surepy/entities/pet.py
@@ -136,11 +136,12 @@ class Pet(SurepyEntity):
         return self.drinking.at if self.drinking else None
     
     @property
-    def profile_id(self) -> int:
+    def profile_id(self) -> StateInside:
         """State of inside only."""
         device_id = self._data.get("device_id", {}),
         tag_id = self._data.get("tag_id", {}),
-        profile=get_inside_pet(self, device_id, tag_id),
         # pylint: disable=no-member
-        return profile
+        return StateInside(
+            profile=get_inside_pet(self, device_id, tag_id),
+            )
     

--- a/surepy/entities/pet.py
+++ b/surepy/entities/pet.py
@@ -142,6 +142,6 @@ class Pet(SurepyEntity):
         tag_id = self._data.get("tag_id", {}),
         # pylint: disable=no-member
         return StateInside(
-            profile=InsidePet(get_inside_pet(tag_id := self._data.get("device_id",tag_id := self._data.get("tag_id"))))
+            profile=InsidePet(get_inside_pet(device_id,tag_id))
         )
     

--- a/surepy/enums.py
+++ b/surepy/enums.py
@@ -76,3 +76,9 @@ class TimelineEvent(SureEnum):
     DRINK = 29
     REMINDER_FRESH_WATER = 32
     ANONYMOUS_DRINK = 34
+
+class InsidePet(SureEnum):
+    """Inside Pet Profiles"""
+
+    INSIDE_ONLY = 3
+    OUTSIDE = 2


### PR DESCRIPTION
Added the ability to set a specific pet as "inside only" or "outside" using device_id, tag_id and new profile_id. This matches the Sure Petcare app ability to do so.