### PR TITLE
fix: curfew JSON does not accept an array of dicts but just a dict

### DIFF
--- a/surepy/client.py
+++ b/surepy/client.py
@@ -398,13 +398,12 @@ class SureAPIClient:
         resource = CONTROL_RESOURCE.format(BASE_RESOURCE=BASE_RESOURCE, device_id=device_id)
 
         data = {
-            "curfew": [
+            "curfew":
                 {
                     "lock_time": lock_time.strftime("%H:%M"),
                     "unlock_time": unlock_time.strftime("%H:%M"),
                     "enabled": True,
                 }
-            ]
         }
 
         if (


### PR DESCRIPTION
This PR fixes the set_curfew API call which accepts a singular dictionary rather than an array of dictionaries.